### PR TITLE
Change csvlint gem reference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'csvlint', github: 'GSS-Cogs/csvlint.rb', :ref => 'f859165bee3e99212ab6a4afb3308212ce3f7cb0'
+gem 'csvlint', git: 'https://github.com/GSS-Cogs/csvlint.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'csvlint', git: 'https://github.com/GSS-Cogs/csvlint.rb'
+gem 'csvlint', git: 'https://github.com/GSS-Cogs/csvlint.rb', tag: 'v0.5.0'


### PR DESCRIPTION
The gem csvlint was installed from a specific commit reference. Since new commits are made into master, this change might be necessary for the changes to reflect. Not sure why was the version pointed to a specific commit, if it was done for a reason review if this is still needed.